### PR TITLE
Implement std::fmt::Display for Type::Tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _Currently under development._
 ### ABI encoder V2
 
 - [x] JSON parsing
-- [ ] Function selectors (method ID)
+- [x] Function selectors (method ID)
 - [x] argument encoding and decoding
 
 ## Example

--- a/src/types.rs
+++ b/src/types.rs
@@ -41,7 +41,14 @@ impl std::fmt::Display for Type {
             Type::Bytes => write!(f, "bytes"),
             Type::FixedArray(ty, size) => write!(f, "{}[{}]", ty, size),
             Type::Array(ty) => write!(f, "{}[]", ty),
-            Type::Tuple(_) => todo!(),
+            Type::Tuple(tys) => write!(
+                f,
+                "({})",
+                tys.iter()
+                    .map(|(_, ty)| format!("{}", ty))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ),
         }
     }
 }


### PR DESCRIPTION
Closes #2 

This enables computing the correct function selector for functions that
have tuples as arguments.
